### PR TITLE
Rename shield_io_timeout to shield_service_timeout

### DIFF
--- a/lib/fastlane/plugin/badge/actions/add_badge_action.rb
+++ b/lib/fastlane/plugin/badge/actions/add_badge_action.rb
@@ -10,7 +10,7 @@ module Fastlane
           no_badge: params[:no_badge],
           shield: params[:shield],
           alpha: params[:alpha],
-          shield_io_timeout: params[:shield_io_timeout],
+          shield_service_timeout: params[:shield_service_timeout],
           glob: params[:glob],
           alpha_channel: params[:alpha_channel],
           shield_gravity: params[:shield_gravity],


### PR DESCRIPTION
This commit changed the name of this parameter: https://github.com/HazAT/badge/commit/cdf190d46965f6b6efa5ac14c45628331f24fd70