### PR TITLE
Update repo to use newer version of badge

### DIFF
--- a/fastlane-plugin-badge.gemspec
+++ b/fastlane-plugin-badge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  spec.add_dependency 'badge', '~> 0.10.0'
+  spec.add_dependency 'badge', '~> 0.11.0'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/badge/version.rb
+++ b/lib/fastlane/plugin/badge/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Badge
-    VERSION = "1.2.0"
+    VERSION = "1.3.0"
   end
 end


### PR DESCRIPTION
Update fastlane plugin to use new version of badge.