### PR TITLE
Add path parameter to available_options

### DIFF
--- a/lib/fastlane/plugin/badge/helper/badge_helper.rb
+++ b/lib/fastlane/plugin/badge/helper/badge_helper.rb
@@ -7,7 +7,8 @@ module BadgeBridge
     end
 
     def self.run(options)
-      Badge::Runner.new.run('.', options)
+      path = options.fetch(:path) { "." }
+      Badge::Runner.new.run(path, options)
     end
   end
 end

--- a/lib/fastlane/plugin/badge/helper/badge_helper.rb
+++ b/lib/fastlane/plugin/badge/helper/badge_helper.rb
@@ -7,7 +7,7 @@ module BadgeBridge
     end
 
     def self.run(options)
-      path = options.fetch(:path) { "." }
+      path = options.fetch(:path)
       Badge::Runner.new.run(path, options)
     end
   end
@@ -20,7 +20,15 @@ module Fastlane
       # as `Helper::BadgeHelper.your_method`
       #
       def self.available_options
-        BadgeBridge::Bridge.available_options
+        base_options = BadgeBridge::Bridge.available_options
+        base_options.append(
+          FastlaneCore::ConfigItem.new(
+            key: :path,
+            description: 'path for searching image files. The glob pattern is appended to this path',
+            optional: true,
+            default_value: '.'
+          )
+        )
       end
 
       def self.run(options)


### PR DESCRIPTION
Hello @HazAT, how are you doing today?

I noticed you're passing to the Badge module a `path` value of `.`. For my company use case, this is not the best value because it prevents the glob pattern to work as expected.

Our project structure looks like this:

```
/config
  /fastlane

/android
/ios
```

I added a minor improvement: allow users to set an optional property: `path`. It defaults to the current value of `.`, causing no breaking change for existing users.

Would you be willing to accept this change?

Thanks for your time 🙂